### PR TITLE
PLAT-72579: Add script to fetch mount and average update data per sample

### DIFF
--- a/performance/timeline.js
+++ b/performance/timeline.js
@@ -22,11 +22,14 @@ const userTiming = Array.from(results._namedTracks.values())[0];
 const timingEvents = userTiming.asyncEvents;
 
 // filter our component update data
-const updateData = timingEvents.filter((item, index) => (
+const updateData = timingEvents.filter((item, index) => {
+	// is this the target component data
+	const isComponent = item.name === `⚛ ${component} [update]`;
+	const isPicker = component === 'Picker';
 	// Picker contains a sub-component also named 'Picker', which we don't want to calculate
 	// so we isolate the parent Picker (wrapped by MarqueeController [update] > MarqueeController.getChildContext)
-	item.name === `⚛ ${component} [update]` && timingEvents[index-2].name === `⚛ MarqueeController [update]`
-));
+	return isPicker ? isComponent && timingEvents[index-2].name === `⚛ MarqueeController [update]` : isComponent;
+});
 const updates = updateData.length;
 // calculate average update timing
 const updateTiming = updateData.reduce((accumulator, currentValue) => accumulator + currentValue.duration, 0) / updates;
@@ -37,4 +40,4 @@ const mountTiming = timingEvents.find((item) => item.name === `⚛ ${component} 
 // console.log(results);
 
 console.log(`Mount timing: ${mountTiming}`);
-console.log(`Update timing (average): ${updateTiming}`);
+console.log(`Update timing (average of ${updates}): ${updateTiming}`);

--- a/performance/timeline.js
+++ b/performance/timeline.js
@@ -1,0 +1,40 @@
+let filename = '';
+const argv = require('yargs').argv;
+
+if (argv.file) {
+  filename = `./${argv.file}`;
+}
+const events = require('fs').readFileSync(filename, 'utf8');
+
+const DevtoolsTimelineModel = require('devtools-timeline-model');
+// events can be either a string of the trace data or the JSON.parse'd equivalent
+const model = new DevtoolsTimelineModel(events);
+
+const results = model.timelineModel();
+
+// regex to retrieve the appropriate sample (ex: ./performance/traces/picker_20190116165502.json > picker)
+const sample = filename.match(/[^\\/]+\.[^\\/]+$/)[0].split('_')[0];
+// build the component name
+const component = sample.slice(0, 1).toUpperCase() + sample.slice(1);
+// convert Map to Array in order to access data via index key
+const userTiming = Array.from(results._namedTracks.values())[0];
+// user timing data
+const timingEvents = userTiming.asyncEvents;
+
+// filter our component update data
+const updateData = timingEvents.filter((item, index) => (
+	// Picker contains a sub-component also named 'Picker', which we don't want to calculate
+	// so we isolate the parent Picker (wrapped by MarqueeController [update] > MarqueeController.getChildContext)
+	item.name === `⚛ ${component} [update]` && timingEvents[index-2].name === `⚛ MarqueeController [update]`
+));
+const updates = updateData.length;
+// calculate average update timing
+const updateTiming = updateData.reduce((accumulator, currentValue) => accumulator + currentValue.duration, 0) / updates;
+// retrieve mount timing
+const mountTiming = timingEvents.find((item) => item.name === `⚛ ${component} [mount]`).duration;
+
+// Results should be viewed using something like devtool.
+// console.log(results);
+
+console.log(`Mount timing: ${mountTiming}`);
+console.log(`Update timing (average): ${updateTiming}`);


### PR DESCRIPTION
Adding a node script to parse through the performance trace data in order to output the mount and average update times per component/sample.